### PR TITLE
Use more platform compatible text replacement command

### DIFF
--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -91,7 +91,7 @@ namespace :tachikoma do
   task :bundle do
     Dir.chdir("#{Tachikoma.repos_path.to_s}/#{@build_for}") do
       Bundler.with_clean_env do
-        sh %Q!ruby -i -pe '$_.gsub! /^ruby/, "#ruby"' Gemfile!
+        sh %Q|ruby -i -pe '$_.gsub! /^ruby/, "#ruby"' Gemfile|
         sh "git config user.name #{@commiter_name}"
         sh "git config user.email #{@commiter_email}"
         sh "git checkout -b feature/bundle-#{@readable_time} #{@base_remote_branch}"


### PR DESCRIPTION
In Mac OSX, sed(1) is BSD origin, so `-e` option is different to Unix's sed(1).

```
$ mkdir /tmp/sed-incompatible; cd /tmp/sed-incompatible
$ bundle init
$ echo "ruby '1.9.3'" >> Gemfile
$ sed -i -e 's/^ruby/#ruby/' Gemfile
$ ls
Gemfile         Gemfile-e                 #=> unexpected file `Gemfile-e` is created!
```

This commit changes replacement command to use ruby(1) as a platform compatible sed :)
