### PR TITLE
Ignore exitstatus when no changes added to commit

### DIFF
--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -98,7 +98,7 @@ namespace :tachikoma do
         sh 'bundle --gemfile Gemfile --no-deployment --without nothing'
         sh 'bundle update'
         sh 'git add Gemfile.lock'
-        sh %Q!git commit -m "Bundle update #{@readable_time}"!
+        sh %Q!git commit -m "Bundle update #{@readable_time}"! do; end # ignore exitstatus
         sh "git push #{@authorized_url} feature/bundle-#{@readable_time}"
       end
     end


### PR DESCRIPTION
## Problem

In my use case, I create one Jenkins job and write multiple commands to bundle update many repositories.
Since `FileUtils#sh` (provided by rake) returns exit status of invoked command, I have troubled like this scenario:
1. Jenkins job settings: `Execute shell` with multiple tachikoma tasks for multiple repositories (e.g. repo1, repo2, repo3)
2. run tachikoma tasks against repo1
3. repo1 has no gem updates
4. `git commit` exits non-zero exit status (in my environment, the status code is 1) when no changes added to commit
5. Jenkins job mark as fail and stop immediately
6. repo2 and repo3 lose chance to update gems
## Solution

`FileUtils#sh` accepts block to check exit status code, so I added empty block and just ignore exit status of `git commit` command.

I think it's dirty hack, so I'm happy to discuss how to care such a situation.
