### PR TITLE
Add \n to texts which `tachikoma init` command appending

### DIFF
--- a/bin/tachikoma
+++ b/bin/tachikoma
@@ -4,12 +4,14 @@ when 'init'
   require 'fileutils'
   File.open('.gitignore', 'a') do |f|
     f << <<-EOS
+
 /repos/*
 !/repos/.gitkeep
     EOS
   end
   File.open('Rakefile', 'a') do |f|
     f << <<-EOS
+
 require 'bundler/setup'
 require 'tachikoma/tasks'
     EOS


### PR DESCRIPTION
If last lines of appended files have string, `tachikoma init` may break them. 
This commit fixes it.
