### PR TITLE
Add 'private' to type

### DIFF
--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -17,10 +17,8 @@ namespace :tachikoma do
     case type
     when 'fork'
       %Q!#{uri.scheme}://#{github_token}@#{uri.host}#{path_for_fork(uri.path, github_account)}!
-    when 'shared'
+    when 'shared', 'private'
       "#{uri.scheme}://#{github_token}@#{uri.host}#{uri.path}"
-    when 'private'
-      "#{uri.scheme}://git@#{uri.host}#{uri.path}"
     else
       raise "Invalid type #{type}"
     end


### PR DESCRIPTION
This commit is dirty but works for me.

I have a private repo which I want to use tachikoma to. but
- `https://` requires login name and password
- `ssh://` doesn't require them (if ssh key is set) but tachikoma doesn't support

so I add 'private' to type in order to support `ssh://`.

If you set `"ssh://github.com/user_name/private_repo.git"` to url, it work.
