### PR TITLE
rescue Octokit::UnprocessableEntity exception to prevent unexpected task termination

### DIFF
--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -112,7 +112,10 @@ namespace :tachikoma do
 
   desc 'pull_request'
   task :pull_request do
-    @client = Octokit::Client.new(login: @github_account, oauth_token: @github_token)
-    @client.create_pull_request(@pull_request_url, @pull_request_base, @pull_request_head, @pull_request_title, @pull_request_body)
+    begin
+      @client = Octokit::Client.new(login: @github_account, oauth_token: @github_token)
+      @client.create_pull_request(@pull_request_url, @pull_request_base, @pull_request_head, @pull_request_title, @pull_request_body)
+    rescue Octokit::UnprocessableEntity
+    end
   end
 end

--- a/spec/tasks/app_task_spec.rb
+++ b/spec/tasks/app_task_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'rake'
+require 'tachikoma/tasks'
+
+describe 'app.rake' do
+  describe 'tachikoma:pull_request' do
+    context 'when github returns 422 UnprocessableEntity' do
+      before do
+        Octokit::Client.stub_chain(:new, :create_pull_request).and_raise(Octokit::UnprocessableEntity)
+      end
+
+      it 'should not raise Octokit::UnprocessableEntity error' do
+        expect {
+          Rake::Task['tachikoma:pull_request'].invoke
+        }.to_not raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
When no commit between master and branch are exist, GitHub Pull Request API returns 422 UnprocessableEntity and Octokit raises Octokit::UnprocessableEntity exception :octocat: 
Raising exception may occurs problem when I add multiple step of tachikoma tasks to one Jenkins job.
If an exception is raised during doing first task, remained tasks no longer invoked unexpectedly.

This pull requests solves this problem to add `rescue` clause to prevent unexpected task termination.

Bonus point: I added minimum test case of `app.rake` :trollface: 
