### PR TITLE
[wip] Add bundler dependency from development_dependency

### DIFF
--- a/tachikoma.gemspec
+++ b/tachikoma.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rake'
   spec.add_dependency 'octokit'
   spec.add_dependency 'json'
+  spec.add_dependency 'bundler', '~> 1.3'
 
-  spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency 'dotenv'
   spec.add_development_dependency 'rspec', '>= 2.14.0.rc'
 end


### PR DESCRIPTION
In https://github.com/sanemat/tachikoma/blob/d0770f85d3f18f6ad2f081f7a3a7ea2712b22c43/lib/tasks/app.rake , tachikoma uses `Bundler.with_clean_env`.

This is enough? I need to add `require 'bundler'`?
