### PR TITLE
Remove unexpected gem dependency of rspec

### DIFF
--- a/tachikoma.gemspec
+++ b/tachikoma.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'dotenv'
-  spec.add_development_dependency 'rspec', '>= 2.14.0.rc'
+  spec.add_development_dependency 'rspec', '>= 2.14.0'
 end


### PR DESCRIPTION
'>= 2.14.0.rc'
Installing rspec-core (3.0.0.beta1)
Installing rspec-support (3.0.0.beta1)
Installing rspec-expectations (3.0.0.beta1)
Installing rspec-mocks (3.0.0.beta1)
Installing rspec (3.0.0.beta1)

'>= 2.14.0′
Installing rspec-core (2.14.7)
Installing rspec-expectations (2.14.4)
Using rspec-mocks (2.14.4)
Using rspec (2.14.1)
