### PR TITLE
Use bundler path option

### DIFF
--- a/lib/tachikoma/application.rb
+++ b/lib/tachikoma/application.rb
@@ -76,7 +76,7 @@ module Tachikoma
           sh "git config user.name #{@commiter_name}"
           sh "git config user.email #{@commiter_email}"
           sh "git checkout -b feature/bundle-#{@readable_time} #{@base_remote_branch}"
-          sh "bundle --gemfile Gemfile --no-deployment --without nothing #{@parallel_option}"
+          sh "bundle --gemfile Gemfile --no-deployment --without nothing --path vendor/bundle #{@parallel_option}"
           sh 'bundle update'
           sh 'git add Gemfile.lock'
           sh %Q!git commit -m "Bundle update #{@readable_time}"! do; end # ignore exitstatus


### PR DESCRIPTION
There was a problem occurs when you bundle update multiple projects **(gems installing Git or Github repositories)** simultaneously.

In summary, Bundler locked .git directory while upgrading a gem.(The root cause is a problem that occurs when the Bundler is parallel execution. :cry:)
- pros
  - independence
- cons
  - speed
  - disk usage

how do you think?
