### PR TITLE
add support for older git versions (1.7.x)

### DIFF
--- a/lib/tachikoma/application.rb
+++ b/lib/tachikoma/application.rb
@@ -116,9 +116,9 @@ module Tachikoma
       uri = URI.parse(fetch_url)
       case type
       when 'fork'
-        %Q!#{uri.scheme}://#{github_token}@#{uri.host}#{path_for_fork(uri.path, github_account)}!
+        %Q!#{uri.scheme}://#{github_token}:x-oauth-basic@#{uri.host}#{path_for_fork(uri.path, github_account)}!
       when 'shared', 'private'
-        "#{uri.scheme}://#{github_token}@#{uri.host}#{uri.path}"
+        "#{uri.scheme}://#{github_token}:x-oauth-basic@#{uri.host}#{uri.path}"
       else
         raise "Invalid type #{type}"
       end


### PR DESCRIPTION
It always asks for git password, when using older git.( CentOS 6.x is installed git 1.7.1 :cry: )

In the following article, it says to use either `https://<token>@github.com/owner/repo.git` or `https://<token>:x-oauth-basic@github.com/owner/repo.git`.

https://github.com/blog/1270-easier-builds-and-deployments-using-git-over-https-and-oauth

If you add `x-oauth-basic`, will not be prompted for a password.
