### PR TITLE
git clone --depth 1

### DIFF
--- a/lib/tachikoma/application.rb
+++ b/lib/tachikoma/application.rb
@@ -64,7 +64,7 @@ module Tachikoma
 
     def fetch
       clean
-      sh "git clone #{@authorized_base_url} #{Tachikoma.repos_path}/#{@build_for}"
+      sh "git clone --depth 1 #{@authorized_base_url} #{Tachikoma.repos_path}/#{@build_for}"
     end
 
     def bundler


### PR DESCRIPTION
I think would Tachikoma does not need all git repository's history.
Tachikoma build of our repository became faster than before.
