### PR TITLE
Use shalow copy(optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ version:
   '2.0.0'
 pull_request_body:
   ':ideograph_advantage::ideograph_advantage::ideograph_advantage:'
+git_clone_depth:
+  50
 ```
 
 ### Build script example

--- a/data/default.yaml
+++ b/data/default.yaml
@@ -14,3 +14,5 @@ pull_request_base:
   'master'
 bundler_parallel_number:
   4
+git_clone_depth:
+  false

--- a/lib/tachikoma/application.rb
+++ b/lib/tachikoma/application.rb
@@ -48,6 +48,7 @@ module Tachikoma
       @timestamp_format = @configure['timestamp_format']
       @readable_time = Time.now.utc.strftime(@timestamp_format)
       @parallel_option = bundler_parallel_option(Bundler::VERSION, @configure['bundler_parallel_number'])
+      @depth_option = git_clone_depth_option(@configure['git_clone_depth'])
 
       @target_head = target_repository_user(@type, @url, @github_account)
       @pull_request_url = repository_identity(@url)
@@ -64,7 +65,12 @@ module Tachikoma
 
     def fetch
       clean
-      sh(*['git', 'clone', @authorized_base_url, "#{Tachikoma.repos_path}/#{@build_for}"])
+      sh(*([
+        'git', 'clone',
+        *@depth_option,
+        @authorized_base_url,
+        "#{Tachikoma.repos_path}/#{@build_for}"
+      ].compact))
     end
 
     def bundler
@@ -244,6 +250,11 @@ module Tachikoma
     def bundler_parallel_available?(bundler_version)
       # bundler 1.4.0 gets parallel number option
       Gem::Version.create(bundler_version) >= Gem::Version.create('1.4.0')
+    end
+
+    def git_clone_depth_option(depth)
+      return [nil] unless depth
+      ['--depth', depth.to_s]
     end
   end
 end

--- a/lib/tachikoma/templates/data/bot-motoko-tachikoma.yaml
+++ b/lib/tachikoma/templates/data/bot-motoko-tachikoma.yaml
@@ -8,3 +8,5 @@ language:
   'ruby'
 version:
   '2.0.0'
+git_clone_depth:
+  50

--- a/spec/tachikoma/application_spec.rb
+++ b/spec/tachikoma/application_spec.rb
@@ -142,6 +142,25 @@ YAML
     end
   end
 
+  describe '#git_clone_depth_option' do
+    subject { described_class.new }
+
+    context 'depth is not provided' do
+      let(:nil_for_expand) { [nil] }
+      it 'returns nil' do
+        expect(subject.git_clone_depth_option(nil)).to eq nil_for_expand
+      end
+    end
+
+    context 'depth is provided' do
+      let(:depth) { 10 }
+      let(:depth_for_expand) { ['--depth', '10'] }
+      it 'returns depth' do
+        expect(subject.git_clone_depth_option(depth)).to eq depth_for_expand
+      end
+    end
+  end
+
   describe '#repository_identity' do
     subject { described_class.new }
     let(:identity) { 'example1/example2' }


### PR DESCRIPTION
#141, #139 

You can set `git_clone_depth` option for fetching repository. This brings `git clone --depth 50 https://example.com/your/repos` and this reduces total build time!

This is optional setting because shallowly-cloned repository does not have push ability until git v1.9.0.
https://github.com/git/git/blob/master/Documentation/RelNotes/1.9.0.txt

I don't know what value is enough yet, but `git_clone_depth: 50` is reasonable, because travis-ci uses `--depth 50` :relaxed: