### PR TITLE
feat(bundler): avoid a confliction of BUNDLED WITH section

### DIFF
--- a/data/default.yaml
+++ b/data/default.yaml
@@ -57,3 +57,14 @@ bundler_parallel_number: 4
 #
 # Supported: false, 1, 2, 3, ...
 git_clone_depth: false
+# Bundler v1.10.0 or higher tracks Bundler version in lockfile.
+# We should use latest Bundler, but sometimes we are afraid we have to use older Bundler.
+# We use Different version of Bundler between a project and a local machine.
+# In addition, Bundler v1.9.x removes BUNDLED WITH section.
+# RestoreBundledWith solves these conflicts.
+# RestoreBundledWith restores BUNDLED WITH section from git repository.
+# See also:
+# https://github.com/packsaddle/ruby-restore_bundled_with
+#
+# Supported: true, false
+bundler_restore_bundled_with: false

--- a/lib/tachikoma/application.rb
+++ b/lib/tachikoma/application.rb
@@ -105,7 +105,7 @@ module Tachikoma
           lock_file_contents = File.read(@bundler_lock_file)
           lock_file = RestoreBundledWith::Lock.restore(
             lock_file_contents, @bundler_lock_file)
-          lock_file.write_to(@bundler_lock_file)
+          File.write(@bundler_lock_file, lock_file.body)
 
           sh(*['git', 'add', @bundler_lock_file])
           sh(*['git', 'commit', '-m', "Bundle update #{@readable_time}"]) do

--- a/lib/tachikoma/application.rb
+++ b/lib/tachikoma/application.rb
@@ -50,6 +50,7 @@ module Tachikoma
       @readable_time = Time.now.utc.strftime(@timestamp_format)
       @parallel_option = bundler_parallel_option(Bundler::VERSION, @configure['bundler_parallel_number'])
       @depth_option = git_clone_depth_option(@configure['git_clone_depth'])
+      @bundler_restore_bundled_with = @configure['bundler_restore_bundled_with']
 
       @target_head = target_repository_user(@type, @url, @github_account)
       @pull_request_url = repository_identity(@url)
@@ -101,11 +102,13 @@ module Tachikoma
           ].compact))
           sh(*%w(bundle update))
 
-          # restore_bundled_with
-          lock_file_contents = File.read(@bundler_lock_file)
-          lock_file = RestoreBundledWith::Lock.restore(
-            lock_file_contents, @bundler_lock_file)
-          File.write(@bundler_lock_file, lock_file.body)
+          if @bundler_restore_bundled_with
+            # restore_bundled_with
+            lock_file_contents = File.read(@bundler_lock_file)
+            lock_file = RestoreBundledWith::Lock.restore(
+              lock_file_contents, @bundler_lock_file)
+            File.write(@bundler_lock_file, lock_file.body)
+          end
 
           sh(*['git', 'add', @bundler_lock_file])
           sh(*['git', 'commit', '-m', "Bundle update #{@readable_time}"]) do

--- a/lib/tachikoma/application.rb
+++ b/lib/tachikoma/application.rb
@@ -3,6 +3,7 @@ require 'uri'
 require 'tachikoma'
 require 'octokit'
 require 'fileutils'
+require 'restore_bundled_with'
 
 module Tachikoma
   # Main logic of Tachikoma
@@ -99,6 +100,13 @@ module Tachikoma
             @parallel_option
           ].compact))
           sh(*%w(bundle update))
+
+          # restore_bundled_with
+          lock_file_contents = File.read(@bundler_lock_file)
+          lock_file = RestoreBundledWith::Lock.restore(
+            lock_file_contents, @bundler_lock_file)
+          lock_file.write_to(@bundler_lock_file)
+
           sh(*['git', 'add', @bundler_lock_file])
           sh(*['git', 'commit', '-m', "Bundle update #{@readable_time}"]) do
             # ignore exitstatus

--- a/tachikoma.gemspec
+++ b/tachikoma.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'octokit', '>= 3.2', '< 4.0'
   spec.add_dependency 'json'
   spec.add_dependency 'thor'
+  spec.add_dependency 'restore_bundled_with'
 
   spec.add_development_dependency 'bundler', '>= 1.3', '< 2.0'
   spec.add_development_dependency 'dotenv'


### PR DESCRIPTION
Add option: `bundler_restore_bundled_with` (default: false)

Bundler v1.10.0 or higher writes Bundler version in Gemfile.lock
restore_bundled_with restores BUNDLED WITH section from git repo.

fixes #185
