### PR TITLE
fix for parallel execution

### DIFF
--- a/lib/tachikoma/application.rb
+++ b/lib/tachikoma/application.rb
@@ -62,7 +62,7 @@ module Tachikoma
 
     def clean
       mkdir_p(Tachikoma.repos_path)
-      rm_rf(Dir.glob(File.join(Tachikoma.repos_path, '*')))
+      rm_rf(Dir.glob(File.join(Tachikoma.repos_path, @build_for, '*')))
     end
 
     def fetch


### PR DESCRIPTION
If all files in `Tachikoma.repos_path` directory are deleted, the fetched files (it was fetched by other process) will be deleted if running `tachikoma:run_bundler` in parallel (For example, execute tachikoma:run_bundler to multi repository by jenkins task).

So fix to remove only `@build_for` directory. 

What do you think ? Thanks !