### PR TITLE
remote branch support with depth option

### DIFF
--- a/lib/tachikoma/application.rb
+++ b/lib/tachikoma/application.rb
@@ -49,7 +49,7 @@ module Tachikoma
       @timestamp_format = @configure['timestamp_format']
       @readable_time = Time.now.utc.strftime(@timestamp_format)
       @parallel_option = bundler_parallel_option(Bundler::VERSION, @configure['bundler_parallel_number'])
-      @depth_option = git_clone_depth_option(@configure['git_clone_depth'])
+      @depth_option = git_clone_depth_option(@configure['git_clone_depth'], @configure['base_remote_branch'])
       @bundler_restore_bundled_with = @configure['bundler_restore_bundled_with']
 
       @target_head = target_repository_user(@type, @url, @github_account)
@@ -328,9 +328,12 @@ module Tachikoma
       Gem::Version.create(bundler_version) >= Gem::Version.create('1.4.0')
     end
 
-    def git_clone_depth_option(depth)
+    def git_clone_depth_option(depth, remote_branch)
       return [nil] unless depth
-      ['--depth', depth.to_s]
+      branch_names = remote_branch.split('/')
+      branch_names.shift
+      branch_name = branch_names.join('/')
+      ['--depth', depth.to_s, '--branch', branch_name]
     end
   end
 end

--- a/spec/tachikoma/application_spec.rb
+++ b/spec/tachikoma/application_spec.rb
@@ -185,17 +185,28 @@ YAML
     subject { described_class.new }
 
     context 'depth is not provided' do
+      let(:branch) { 'origin/master' }
       let(:nil_for_expand) { [nil] }
       it 'returns nil' do
-        expect(subject.git_clone_depth_option(nil)).to eq nil_for_expand
+        expect(subject.git_clone_depth_option(nil, branch)).to eq nil_for_expand
       end
     end
 
     context 'depth is provided' do
+      let(:branch) { 'origin/master' }
       let(:depth) { 10 }
-      let(:depth_for_expand) { ['--depth', '10'] }
+      let(:depth_for_expand) { ['--depth', '10', '--branch', 'master'] }
       it 'returns depth' do
-        expect(subject.git_clone_depth_option(depth)).to eq depth_for_expand
+        expect(subject.git_clone_depth_option(depth, branch)).to eq depth_for_expand
+      end
+    end
+
+    context 'more complex branch' do
+      let(:branch) { 'origin/more/complex/branch' }
+      let(:depth) { 10 }
+      let(:depth_for_expand) { ['--depth', '10', '--branch', 'more/complex/branch'] }
+      it 'returns depth' do
+        expect(subject.git_clone_depth_option(depth, branch)).to eq depth_for_expand
       end
     end
   end


### PR DESCRIPTION
When clone git repository with `depth` option only, clone master branch.
So if the user had set a value other than `origin/master` for `base_remote_branch` doesn't work.

I add `--branch` option when depth option enable.